### PR TITLE
Adding downtimes for SWT2_CPB_*

### DIFF
--- a/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB_downtime.yaml
+++ b/topology/University of Texas Arlington/SWT2 ATLAS UTA/SWT2_CPB_downtime.yaml
@@ -232,3 +232,93 @@
   - GridFtp
   Severity: Outage
   StartTime: Jun 27, 2018 11:00 PM UTC
+- Class: SCHEDULED
+  ID: 31344983
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:34 +0000
+  ResourceName: SWT2_CPB
+  Services:
+  - CE
+  - GridFtp
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31350004
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:43 +0000
+  ResourceName: SWT2_CPB_DEV
+  Services:
+  - CE
+  - GridFtp
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31350528
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:44 +0000
+  ResourceName: SWT2_CPB_SE
+  Services:
+  - SRMv2
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31350792
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:44 +0000
+  ResourceName: SWT2_CPB_SQUID
+  Services:
+  - Squid
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31351064
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:45 +0000
+  ResourceName: SWT2_CPB_perfSONAR_bandwidth
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31351301
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:45 +0000
+  ResourceName: SWT2_CPB_perfSONAR_latency
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31351546
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:45 +0000
+  ResourceName: perfSONAR_SWT2_CPB_testbed_bandwidth
+  Services:
+  - net.perfSONAR.Bandwidth
+# ---------------------------------------------------------
+- Class: SCHEDULED
+  ID: 31351835
+  Description: Upstream network path is physically migrating
+  Severity: Outage
+  StartTime: Sep 30, 2018 07:00 +0000
+  EndTime: Sep 30, 2018 12:00 +0000
+  CreatedTime: Sep 28, 2018 06:46 +0000
+  ResourceName: perfSONAR_SWT2_CPB_testbed_latency
+  Services:
+  - net.perfSONAR.Latency
+# ---------------------------------------------------------


### PR DESCRIPTION
We are undergoing a network changeover that will see a physical transition of the fiber supporting the cluster to a new internal path as well as a new external path to our RON.